### PR TITLE
✨ feat: add find product pagination APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,12 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // zipkin
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.github.openfeign:feign-micrometer'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 ext {
 	set('springCloudVersion', "2025.0.0")
+    set('querydslVersion', "5.1.0")
 }
 
 dependencies {
@@ -35,6 +36,12 @@ dependencies {
 
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    //querydsl
+    implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     // postgre
     runtimeOnly 'org.postgresql:postgresql'
@@ -62,4 +69,22 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// Q Classes directory path .build/generated/querydsl
+def querydslSrcDir = project.layout.buildDirectory.dir("generated/querydsl").get().asFile.path
+
+// generate Q Classes
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslSrcDir))
+}
+
+sourceSets {
+    main.java {
+        srcDir querydslSrcDir
+    }
+}
+
+clean {
+    delete file(querydslSrcDir)
 }

--- a/src/main/java/com/tunaforce/product/common/config/AuditAwareImpl.java
+++ b/src/main/java/com/tunaforce/product/common/config/AuditAwareImpl.java
@@ -1,7 +1,7 @@
-package com.tunaforce.product.common.entity;
+package com.tunaforce.product.common.config;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.fileupload.RequestContext;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -10,6 +10,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import java.util.Optional;
 import java.util.UUID;
 
+@Slf4j
 public class AuditAwareImpl implements AuditorAware<UUID> {
 
     @Override
@@ -20,6 +21,7 @@ public class AuditAwareImpl implements AuditorAware<UUID> {
         if (requestAttributes instanceof ServletRequestAttributes servletRequestAttributes) {
             HttpServletRequest request = servletRequestAttributes.getRequest();
             String userId = request.getHeader("X-USER-ID");
+            log.info("User id: {}", userId);
 
             return Optional.of(UUID.fromString(userId));
         }

--- a/src/main/java/com/tunaforce/product/common/config/AuditAwareImpl.java
+++ b/src/main/java/com/tunaforce/product/common/config/AuditAwareImpl.java
@@ -1,7 +1,6 @@
 package com.tunaforce.product.common.config;
 
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -10,7 +9,6 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import java.util.Optional;
 import java.util.UUID;
 
-@Slf4j
 public class AuditAwareImpl implements AuditorAware<UUID> {
 
     @Override
@@ -20,8 +18,7 @@ public class AuditAwareImpl implements AuditorAware<UUID> {
         // check type & casting
         if (requestAttributes instanceof ServletRequestAttributes servletRequestAttributes) {
             HttpServletRequest request = servletRequestAttributes.getRequest();
-            String userId = request.getHeader("X-USER-ID");
-            log.info("User id: {}", userId);
+            String userId = request.getHeader("X-Auth-User-Id");
 
             return Optional.of(UUID.fromString(userId));
         }

--- a/src/main/java/com/tunaforce/product/common/config/JpaConfig.java
+++ b/src/main/java/com/tunaforce/product/common/config/JpaConfig.java
@@ -1,6 +1,5 @@
 package com.tunaforce.product.common.config;
 
-import com.tunaforce.product.common.entity.AuditAwareImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;

--- a/src/main/java/com/tunaforce/product/common/config/QuerydslConfig.java
+++ b/src/main/java/com/tunaforce/product/common/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.tunaforce.product.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/tunaforce/product/common/exception/ProductException.java
+++ b/src/main/java/com/tunaforce/product/common/exception/ProductException.java
@@ -10,6 +10,7 @@ public enum ProductException {
 
     // Product
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 정보를 찾을 수 없습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     // Auth
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/tunaforce/product/common/exception/ProductException.java
+++ b/src/main/java/com/tunaforce/product/common/exception/ProductException.java
@@ -10,6 +10,7 @@ public enum ProductException {
 
     // Product
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품 정보를 찾을 수 없습니다."),
+    UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 타입입니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     // Auth

--- a/src/main/java/com/tunaforce/product/controller/ProductController.java
+++ b/src/main/java/com/tunaforce/product/controller/ProductController.java
@@ -1,9 +1,14 @@
 package com.tunaforce.product.controller;
 
 import com.tunaforce.product.dto.request.ProductCreateRequestDto;
+import com.tunaforce.product.dto.response.ProductFindPageResponseDto;
+import com.tunaforce.product.entity.UserRole;
 import com.tunaforce.product.service.ProductService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,5 +30,19 @@ public class ProductController {
 
         return ResponseEntity.created(null)
                 .body(null);
+    }
+
+    @GetMapping
+    public ResponseEntity<ProductFindPageResponseDto> findProducts(
+            @PageableDefault(sort = {"createdAt,desc"}) Pageable pageable,
+            @RequestParam(required = false) String productName,
+            @RequestHeader("X-USER-ID") UUID userId, // FIXME 임시
+            @RequestHeader("X-USER-ROLE") String userRole, // FIXME 임시
+            Sort sort) {
+        ProductFindPageResponseDto productPage
+                = productService.findProductPage(pageable, productName, userId, UserRole.of(userRole));
+
+        return ResponseEntity.ok()
+                .body(productPage);
     }
 }

--- a/src/main/java/com/tunaforce/product/controller/ProductController.java
+++ b/src/main/java/com/tunaforce/product/controller/ProductController.java
@@ -36,14 +36,12 @@ public class ProductController {
     @GetMapping
     public ResponseEntity<ProductFindPageResponseDto> findProducts(
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
-            @RequestParam(required = false) String productName,
-            @RequestHeader("X-USER-ID") UUID userId, // FIXME 임시
-            @RequestHeader("X-USER-ROLE") String userRole // FIXME 임시
+            @RequestParam(required = false) String productName
     ) {
         SortType.validate(pageable.getSort());
 
         ProductFindPageResponseDto productPage
-                = productService.findProductPage(pageable, productName, userId, UserRole.of(userRole));
+                = productService.findProductPage(pageable, productName);
 
         return ResponseEntity.ok()
                 .body(productPage);

--- a/src/main/java/com/tunaforce/product/controller/ProductController.java
+++ b/src/main/java/com/tunaforce/product/controller/ProductController.java
@@ -59,10 +59,27 @@ public class ProductController {
     ) {
         SortType.validate(pageable.getSort());
 
-        ProductFindPageResponseDto productPage
+        ProductFindPageResponseDto data
                 = productService.findProductPageByHub(pageable, hubId, productName, userId, UserRole.of(userRole));
 
         return ResponseEntity.ok()
-                .body(productPage);
+                .body(data);
+    }
+
+    @GetMapping("/companies/{companyId}")
+    public ResponseEntity<ProductFindPageResponseDto> findProductsByCompanyManager(
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @PathVariable UUID companyId,
+            @RequestParam(required = false) String productName,
+            @RequestHeader("X-USER-ID") UUID userId, // FIXME 임시
+            @RequestHeader("X-USER-ROLE") String userRole // FIXME 임시
+    ) {
+        SortType.validate(pageable.getSort());
+
+        ProductFindPageResponseDto data
+                = productService.findProductPageByCompany(pageable, companyId, productName, userId, UserRole.of(userRole));
+
+        return ResponseEntity.ok()
+                .body(data);
     }
 }

--- a/src/main/java/com/tunaforce/product/controller/ProductController.java
+++ b/src/main/java/com/tunaforce/product/controller/ProductController.java
@@ -56,9 +56,10 @@ public class ProductController {
             @RequestHeader("X-USER-ROLE") String userRole // FIXME 임시
     ) {
         SortType.validate(pageable.getSort());
+        UserRole role = UserRole.of(userRole);
 
         ProductFindPageResponseDto data
-                = productService.findProductPageByHub(pageable, hubId, productName, userId, UserRole.of(userRole));
+                = productService.findProductPageByHub(pageable, hubId, productName, userId, role);
 
         return ResponseEntity.ok()
                 .body(data);
@@ -73,9 +74,10 @@ public class ProductController {
             @RequestHeader("X-USER-ROLE") String userRole // FIXME 임시
     ) {
         SortType.validate(pageable.getSort());
+        UserRole role = UserRole.of(userRole);
 
         ProductFindPageResponseDto data
-                = productService.findProductPageByCompany(pageable, companyId, productName, userId, UserRole.of(userRole));
+                = productService.findProductPageByCompany(pageable, companyId, productName, userId, role);
 
         return ResponseEntity.ok()
                 .body(data);

--- a/src/main/java/com/tunaforce/product/controller/ProductController.java
+++ b/src/main/java/com/tunaforce/product/controller/ProductController.java
@@ -2,6 +2,7 @@ package com.tunaforce.product.controller;
 
 import com.tunaforce.product.dto.request.ProductCreateRequestDto;
 import com.tunaforce.product.dto.response.ProductFindPageResponseDto;
+import com.tunaforce.product.entity.SortType;
 import com.tunaforce.product.entity.UserRole;
 import com.tunaforce.product.service.ProductService;
 import jakarta.validation.Valid;
@@ -34,11 +35,13 @@ public class ProductController {
 
     @GetMapping
     public ResponseEntity<ProductFindPageResponseDto> findProducts(
-            @PageableDefault(sort = {"createdAt,desc"}) Pageable pageable,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @RequestParam(required = false) String productName,
             @RequestHeader("X-USER-ID") UUID userId, // FIXME 임시
-            @RequestHeader("X-USER-ROLE") String userRole, // FIXME 임시
-            Sort sort) {
+            @RequestHeader("X-USER-ROLE") String userRole // FIXME 임시
+    ) {
+        SortType.validate(pageable.getSort());
+
         ProductFindPageResponseDto productPage
                 = productService.findProductPage(pageable, productName, userId, UserRole.of(userRole));
 

--- a/src/main/java/com/tunaforce/product/controller/ProductController.java
+++ b/src/main/java/com/tunaforce/product/controller/ProductController.java
@@ -34,14 +34,14 @@ public class ProductController {
     }
 
     @GetMapping
-    public ResponseEntity<ProductFindPageResponseDto> findProducts(
+    public ResponseEntity<ProductFindPageResponseDto> findProductsForOrder(
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @RequestParam(required = false) String productName
     ) {
         SortType.validate(pageable.getSort());
 
         ProductFindPageResponseDto productPage
-                = productService.findProductPage(pageable, productName);
+                = productService.findProductPageForOrder(pageable, productName);
 
         return ResponseEntity.ok()
                 .body(productPage);

--- a/src/main/java/com/tunaforce/product/controller/ProductController.java
+++ b/src/main/java/com/tunaforce/product/controller/ProductController.java
@@ -48,4 +48,21 @@ public class ProductController {
         return ResponseEntity.ok()
                 .body(productPage);
     }
+
+    @GetMapping("/hubs/{hubId}")
+    public ResponseEntity<ProductFindPageResponseDto> findProductsByHubManager(
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @PathVariable UUID hubId,
+            @RequestParam(required = false) String productName,
+            @RequestHeader("X-USER-ID") UUID userId, // FIXME 임시
+            @RequestHeader("X-USER-ROLE") String userRole // FIXME 임시
+    ) {
+        SortType.validate(pageable.getSort());
+
+        ProductFindPageResponseDto productPage
+                = productService.findProductPageByHub(pageable, hubId, productName, userId, UserRole.of(userRole));
+
+        return ResponseEntity.ok()
+                .body(productPage);
+    }
 }

--- a/src/main/java/com/tunaforce/product/controller/ProductController.java
+++ b/src/main/java/com/tunaforce/product/controller/ProductController.java
@@ -25,7 +25,8 @@ public class ProductController {
     @PostMapping
     public ResponseEntity<Void> createProduct(
             @RequestBody @Valid ProductCreateRequestDto productCreateRequestDto,
-            @RequestHeader("X-USER-ID") UUID userId // FIXME 임시
+            @RequestHeader("X-Auth-User-Id") UUID userId, // FIXME 임시
+            @RequestHeader("X-Auth-Roles") String userRole // FIXME 임시
     ) {
         productService.createProduct(productCreateRequestDto, userId);
 
@@ -52,8 +53,8 @@ public class ProductController {
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @PathVariable UUID hubId,
             @RequestParam(required = false) String productName,
-            @RequestHeader("X-USER-ID") UUID userId, // FIXME 임시
-            @RequestHeader("X-USER-ROLE") String userRole // FIXME 임시
+            @RequestHeader("X-Auth-User-Id") UUID userId, // FIXME 임시
+            @RequestHeader("X-Auth-Roles") String userRole // FIXME 임시
     ) {
         SortType.validate(pageable.getSort());
         UserRole role = UserRole.of(userRole);
@@ -70,8 +71,8 @@ public class ProductController {
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             @PathVariable UUID companyId,
             @RequestParam(required = false) String productName,
-            @RequestHeader("X-USER-ID") UUID userId, // FIXME 임시
-            @RequestHeader("X-USER-ROLE") String userRole // FIXME 임시
+            @RequestHeader("X-Auth-User-Id") UUID userId, // FIXME 임시
+            @RequestHeader("X-Auth-Roles") String userRole // FIXME 임시
     ) {
         SortType.validate(pageable.getSort());
         UserRole role = UserRole.of(userRole);

--- a/src/main/java/com/tunaforce/product/dto/response/ProductFindDetailResponseDto.java
+++ b/src/main/java/com/tunaforce/product/dto/response/ProductFindDetailResponseDto.java
@@ -1,0 +1,29 @@
+package com.tunaforce.product.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record ProductFindDetailResponseDto(
+        UUID productId,
+
+        String hubName,
+
+        String companyName,
+
+        String productName,
+
+        Integer productQuantity,
+
+        Integer productPrice,
+
+        @JsonFormat(pattern = "yyyy년 MM월 dd일")
+        LocalDateTime createdAt,
+
+        @JsonFormat(pattern = "yyyy년 MM월 dd일")
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/tunaforce/product/dto/response/ProductFindPageResponseDto.java
+++ b/src/main/java/com/tunaforce/product/dto/response/ProductFindPageResponseDto.java
@@ -1,0 +1,50 @@
+package com.tunaforce.product.dto.response;
+
+import com.tunaforce.product.repository.querydsl.dto.response.ProductDetailsQuerydslResponseDto;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Builder
+public record ProductFindPageResponseDto(
+        long totalElements,
+
+        int totalPages,
+
+        int currentPage,
+
+        int currentSize,
+
+        List<ProductFindDetailResponseDto> data
+) {
+
+    public static ProductFindPageResponseDto from(
+            Page<ProductDetailsQuerydslResponseDto> page,
+            Map<UUID, String> hubs,
+            Map<UUID, String> companies
+    ) {
+        List<ProductFindDetailResponseDto> data = page.getContent().stream()
+                .map(product -> ProductFindDetailResponseDto.builder()
+                        .productId(product.productId())
+                        .hubName(hubs.get(product.hubId()))
+                        .companyName(companies.get(product.companyId()))
+                        .productName(product.name())
+                        .productQuantity(product.quantity())
+                        .productPrice(product.price())
+                        .createdAt(product.createdAt())
+                        .createdAt(product.updatedAt())
+                        .build()
+                ).toList();
+
+        return ProductFindPageResponseDto.builder()
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .currentPage(page.getNumber())
+                .currentSize(page.getNumberOfElements())
+                .data(data)
+                .build();
+    }
+}

--- a/src/main/java/com/tunaforce/product/entity/Product.java
+++ b/src/main/java/com/tunaforce/product/entity/Product.java
@@ -19,6 +19,9 @@ public class Product extends Timestamped {
     @Column(name = "product_id")
     private UUID id;
 
+    @Column(name = "hub_id", nullable = false)
+    private UUID hubId;
+
     @Column(name = "company_id", nullable = false)
     private UUID companyId;
 
@@ -32,7 +35,8 @@ public class Product extends Timestamped {
     private Integer quantity;
 
     @Builder
-    public Product(UUID companyId, String name, Integer price, Integer quantity) {
+    public Product(UUID hubId, UUID companyId, String name, Integer price, Integer quantity) {
+        this.hubId = hubId;
         this.companyId = companyId;
         this.name = name;
         this.price = price;

--- a/src/main/java/com/tunaforce/product/entity/SortType.java
+++ b/src/main/java/com/tunaforce/product/entity/SortType.java
@@ -1,0 +1,37 @@
+package com.tunaforce.product.entity;
+
+import com.tunaforce.product.common.exception.CustomRuntimeException;
+import com.tunaforce.product.common.exception.ProductException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum SortType {
+
+    CREATED_ASC("createdAt", Sort.Direction.ASC),
+    CREATED_DESC("createdAt", Sort.Direction.DESC),
+    UPDATED_ASC("updatedAt", Sort.Direction.ASC),
+    UPDATED_DESC("updatedAt", Sort.Direction.DESC),
+    PRICE_ASC("price", Sort.Direction.ASC),
+    PRICE_DESC("price", Sort.Direction.DESC),
+    ;
+
+    private final String value;
+    private final Sort.Direction direction;
+
+    public static void validate(Sort sort) {
+        for (Sort.Order order : sort) {
+            boolean valid = Arrays.stream(SortType.values())
+                    .anyMatch(sortType -> sortType.value.equalsIgnoreCase(order.getProperty()) &&
+                            sortType.getDirection().equals(order.getDirection()));
+
+            if (!valid) {
+                throw new CustomRuntimeException(ProductException.UNSUPPORTED_SORT_TYPE);
+            }
+        }
+    }
+}

--- a/src/main/java/com/tunaforce/product/entity/UserRole.java
+++ b/src/main/java/com/tunaforce/product/entity/UserRole.java
@@ -1,0 +1,25 @@
+package com.tunaforce.product.entity;
+
+import com.tunaforce.product.common.exception.CustomRuntimeException;
+import com.tunaforce.product.common.exception.ProductException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.stream.Stream;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+
+    MASTER("MASTER"),
+    COMPANY("COMPANY"),
+    HUB("HUB");
+
+    private final String roleName;
+
+    public static UserRole of(String roleName) {
+        return Stream.of(UserRole.values())
+                .filter(role -> role.roleName.equalsIgnoreCase(roleName))
+                .findFirst().orElseThrow(() -> new CustomRuntimeException(ProductException.ACCESS_DENIED));
+    }
+}

--- a/src/main/java/com/tunaforce/product/entity/UserRole.java
+++ b/src/main/java/com/tunaforce/product/entity/UserRole.java
@@ -13,7 +13,9 @@ public enum UserRole {
 
     MASTER("MASTER"),
     COMPANY("COMPANY"),
-    HUB("HUB");
+    HUB("HUB"),
+    DELIVERY("DELIVERY"),
+    ;
 
     private final String roleName;
 

--- a/src/main/java/com/tunaforce/product/repository/feign/company/CompanyFeignClient.java
+++ b/src/main/java/com/tunaforce/product/repository/feign/company/CompanyFeignClient.java
@@ -1,7 +1,25 @@
 package com.tunaforce.product.repository.feign.company;
 
+import com.tunaforce.product.repository.feign.company.dto.response.CompanyFindInfoListResponse;
+import com.tunaforce.product.repository.feign.company.dto.response.CompanyFindInfoResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name = "company-service", fallbackFactory = CompanyFeignFallbackFactory.class)
+import java.util.List;
+import java.util.UUID;
+
+@FeignClient(
+        name = "companies",
+        url = "localhost:3360",
+        path = "/internal/companies/product-company",
+        fallbackFactory = CompanyFeignFallbackFactory.class)
 public interface CompanyFeignClient {
+
+    @GetMapping("/find-by-user-id/{userId}")
+    CompanyFindInfoResponseDto findCompanyInfoByUserId(@PathVariable("userId") UUID userId);
+
+    @GetMapping("/find-by-company-ids")
+    CompanyFindInfoListResponse findCompanyByCompanyIds(@RequestParam List<UUID> companyIds);
 }

--- a/src/main/java/com/tunaforce/product/repository/feign/company/CompanyFeignClient.java
+++ b/src/main/java/com/tunaforce/product/repository/feign/company/CompanyFeignClient.java
@@ -21,5 +21,5 @@ public interface CompanyFeignClient {
     CompanyFindInfoResponseDto findCompanyInfoByUserId(@PathVariable("userId") UUID userId);
 
     @GetMapping("/find-by-company-ids")
-    CompanyFindInfoListResponse findCompanyByCompanyIds(@RequestParam List<UUID> companyIds);
+    CompanyFindInfoListResponse findCompanyInfoListByCompanyIds(@RequestParam List<UUID> companyIds);
 }

--- a/src/main/java/com/tunaforce/product/repository/feign/company/CompanyFeignFallbackFactory.java
+++ b/src/main/java/com/tunaforce/product/repository/feign/company/CompanyFeignFallbackFactory.java
@@ -1,7 +1,13 @@
 package com.tunaforce.product.repository.feign.company;
 
+import com.tunaforce.product.repository.feign.company.dto.response.CompanyFindInfoListResponse;
+import com.tunaforce.product.repository.feign.company.dto.response.CompanyFindInfoResponseDto;
+import com.tunaforce.product.repository.feign.hub.dto.response.HubFindInfoResponseDto;
 import org.springframework.cloud.openfeign.FallbackFactory;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
 
 @Component
 public class CompanyFeignFallbackFactory implements FallbackFactory<CompanyFeignClient> {
@@ -9,6 +15,18 @@ public class CompanyFeignFallbackFactory implements FallbackFactory<CompanyFeign
     @Override
     public CompanyFeignClient create(Throwable cause) {
         return new CompanyFeignClient() {
+
+            @Override
+            public CompanyFindInfoResponseDto findCompanyInfoByUserId(UUID userId) {
+                // TODO throw exceptions
+                return null;
+            }
+
+            @Override
+            public CompanyFindInfoListResponse findCompanyByCompanyIds(List<UUID> companyIds) {
+                // TODO throw exceptions
+                return null;
+            }
         };
     }
 }

--- a/src/main/java/com/tunaforce/product/repository/feign/company/CompanyFeignFallbackFactory.java
+++ b/src/main/java/com/tunaforce/product/repository/feign/company/CompanyFeignFallbackFactory.java
@@ -23,7 +23,7 @@ public class CompanyFeignFallbackFactory implements FallbackFactory<CompanyFeign
             }
 
             @Override
-            public CompanyFindInfoListResponse findCompanyByCompanyIds(List<UUID> companyIds) {
+            public CompanyFindInfoListResponse findCompanyInfoListByCompanyIds(List<UUID> companyIds) {
                 // TODO throw exceptions
                 return null;
             }

--- a/src/main/java/com/tunaforce/product/repository/feign/company/dto/response/CompanyFindInfoListResponse.java
+++ b/src/main/java/com/tunaforce/product/repository/feign/company/dto/response/CompanyFindInfoListResponse.java
@@ -10,7 +10,7 @@ public record CompanyFindInfoListResponse(
 ) {
 
     public Map<UUID, String> toMap() {
-        return data().stream()
+        return data.stream()
                 .collect(Collectors.toMap(
                         CompanyFindInfoResponseDto::companyId,
                         CompanyFindInfoResponseDto::companyName

--- a/src/main/java/com/tunaforce/product/repository/feign/company/dto/response/CompanyFindInfoListResponse.java
+++ b/src/main/java/com/tunaforce/product/repository/feign/company/dto/response/CompanyFindInfoListResponse.java
@@ -1,0 +1,19 @@
+package com.tunaforce.product.repository.feign.company.dto.response;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public record CompanyFindInfoListResponse(
+        List<CompanyFindInfoResponseDto> data
+) {
+
+    public Map<UUID, String> toMap() {
+        return data().stream()
+                .collect(Collectors.toMap(
+                        CompanyFindInfoResponseDto::companyId,
+                        CompanyFindInfoResponseDto::companyName
+                ));
+    }
+}

--- a/src/main/java/com/tunaforce/product/repository/feign/company/dto/response/CompanyFindInfoResponseDto.java
+++ b/src/main/java/com/tunaforce/product/repository/feign/company/dto/response/CompanyFindInfoResponseDto.java
@@ -5,6 +5,8 @@ import java.util.UUID;
 public record CompanyFindInfoResponseDto(
         UUID companyId,
 
+        UUID hubId,
+
         String companyName
 ) {
 }

--- a/src/main/java/com/tunaforce/product/repository/feign/company/dto/response/CompanyFindInfoResponseDto.java
+++ b/src/main/java/com/tunaforce/product/repository/feign/company/dto/response/CompanyFindInfoResponseDto.java
@@ -1,0 +1,10 @@
+package com.tunaforce.product.repository.feign.company.dto.response;
+
+import java.util.UUID;
+
+public record CompanyFindInfoResponseDto(
+        UUID companyId,
+
+        String companyName
+) {
+}

--- a/src/main/java/com/tunaforce/product/repository/feign/hub/HubFeignClient.java
+++ b/src/main/java/com/tunaforce/product/repository/feign/hub/HubFeignClient.java
@@ -1,12 +1,25 @@
 package com.tunaforce.product.repository.feign.hub;
 
+import com.tunaforce.product.repository.feign.hub.dto.response.HubFindInfoListResponseDto;
+import com.tunaforce.product.repository.feign.hub.dto.response.HubFindInfoResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
 import java.util.UUID;
 
-@FeignClient(name = "hub-service", fallbackFactory = HubFeignFallbackFactory.class)
+@FeignClient(
+        name = "hubs",
+        url = "localhost:3340",
+        path = "/internal/hubs/product-hub",
+        fallbackFactory = HubFeignFallbackFactory.class)
 public interface HubFeignClient {
+
+    @GetMapping("/find-by-user-id/{userId}")
+    HubFindInfoResponseDto findHubInfoByUserId(@PathVariable("userId") UUID userId);
+
+    @GetMapping("/find-by-hub-ids")
+    HubFindInfoListResponseDto findHubInfoListByHubIds(@RequestParam List<UUID> hubIds);
 }

--- a/src/main/java/com/tunaforce/product/repository/feign/hub/HubFeignFallbackFactory.java
+++ b/src/main/java/com/tunaforce/product/repository/feign/hub/HubFeignFallbackFactory.java
@@ -1,7 +1,12 @@
 package com.tunaforce.product.repository.feign.hub;
 
+import com.tunaforce.product.repository.feign.hub.dto.response.HubFindInfoListResponseDto;
+import com.tunaforce.product.repository.feign.hub.dto.response.HubFindInfoResponseDto;
 import org.springframework.cloud.openfeign.FallbackFactory;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
 
 @Component
 public class HubFeignFallbackFactory implements FallbackFactory<HubFeignClient> {
@@ -9,6 +14,18 @@ public class HubFeignFallbackFactory implements FallbackFactory<HubFeignClient> 
     @Override
     public HubFeignClient create(Throwable cause) {
         return new HubFeignClient() {
+
+            @Override
+            public HubFindInfoResponseDto findHubInfoByUserId(UUID userId) {
+                // TODO throw exceptions
+                return null;
+            }
+
+            @Override
+            public HubFindInfoListResponseDto findHubInfoListByHubIds(List<UUID> hubIds) {
+                // TODO throw exceptions
+                return null;
+            }
         };
     }
 }

--- a/src/main/java/com/tunaforce/product/repository/feign/hub/dto/response/HubFindInfoListResponseDto.java
+++ b/src/main/java/com/tunaforce/product/repository/feign/hub/dto/response/HubFindInfoListResponseDto.java
@@ -1,0 +1,19 @@
+package com.tunaforce.product.repository.feign.hub.dto.response;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public record HubFindInfoListResponseDto(
+        List<HubFindInfoResponseDto> data
+) {
+
+    public Map<UUID, String> toMap() {
+        return data.stream()
+                .collect(Collectors.toMap(
+                        HubFindInfoResponseDto::hubId,
+                        HubFindInfoResponseDto::hubName
+                ));
+    }
+}

--- a/src/main/java/com/tunaforce/product/repository/feign/hub/dto/response/HubFindInfoResponseDto.java
+++ b/src/main/java/com/tunaforce/product/repository/feign/hub/dto/response/HubFindInfoResponseDto.java
@@ -1,0 +1,10 @@
+package com.tunaforce.product.repository.feign.hub.dto.response;
+
+import java.util.UUID;
+
+public record HubFindInfoResponseDto(
+        UUID hubId,
+
+        String hubName
+) {
+}

--- a/src/main/java/com/tunaforce/product/repository/querydsl/ProductQuerydslRepository.java
+++ b/src/main/java/com/tunaforce/product/repository/querydsl/ProductQuerydslRepository.java
@@ -1,0 +1,12 @@
+package com.tunaforce.product.repository.querydsl;
+
+import com.tunaforce.product.repository.querydsl.dto.response.ProductDetailsQuerydslResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public interface ProductQuerydslRepository {
+
+    Page<ProductDetailsQuerydslResponseDto> findPage(Pageable pageable, UUID hubId, UUID companyId, String productName);
+}

--- a/src/main/java/com/tunaforce/product/repository/querydsl/ProductQuerydslRepositoryImpl.java
+++ b/src/main/java/com/tunaforce/product/repository/querydsl/ProductQuerydslRepositoryImpl.java
@@ -1,0 +1,101 @@
+package com.tunaforce.product.repository.querydsl;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tunaforce.product.entity.Product;
+import com.tunaforce.product.repository.querydsl.dto.response.ProductDetailsQuerydslResponseDto;
+import com.tunaforce.product.repository.querydsl.dto.response.QProductDetailsQuerydslResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static com.tunaforce.product.entity.QProduct.product;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductQuerydslRepositoryImpl implements ProductQuerydslRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ProductDetailsQuerydslResponseDto> findPage(
+            Pageable pageable,
+            UUID hubId,
+            UUID companyId,
+            String productName
+    ) {
+        // SELECT
+        List<ProductDetailsQuerydslResponseDto> records = queryFactory
+                .select(new QProductDetailsQuerydslResponseDto(
+                        product.id,
+                        product.hubId,
+                        product.companyId,
+                        product.name,
+                        product.price,
+                        product.quantity,
+                        product.createdAt,
+                        product.updatedAt
+                ))
+                .from(product)
+                .where(
+                        eqHubId(hubId),
+                        eqCompanyId(companyId),
+                        eqProductName(productName),
+                        product.deletedAt.isNull()
+                )
+                .orderBy(getOrderSpecifiers(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // COUNT
+        JPAQuery<Long> count = queryFactory
+                .select(product.count())
+                .where(
+                        eqHubId(hubId),
+                        eqCompanyId(companyId),
+                        eqProductName(productName),
+                        product.deletedAt.isNull()
+                )
+                .from(product);
+
+        return PageableExecutionUtils.getPage(records, pageable, count::fetchOne);
+    }
+
+    private BooleanExpression eqHubId(UUID hubId) {
+        return hubId != null ? product.hubId.eq(hubId) : null;
+    }
+
+    private BooleanExpression eqCompanyId(UUID companyId) {
+        return companyId != null ? product.companyId.eq(companyId) : null;
+    }
+
+    private BooleanExpression eqProductName(String productName) {
+        return StringUtils.hasText(productName) ? product.name.contains(productName) : null;
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Sort sort) {
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+        for (Sort.Order sortOrder : sort) {
+            Order order = sortOrder.isAscending() ? Order.ASC : Order.DESC;
+            PathBuilder<Product> pathBuilder = new PathBuilder<>(product.getType(), product.getMetadata());
+
+            orderSpecifiers.add(new OrderSpecifier<>(order, pathBuilder.getString(sortOrder.getProperty())));
+        }
+
+        return orderSpecifiers.toArray(new OrderSpecifier[0]);
+    }
+}

--- a/src/main/java/com/tunaforce/product/repository/querydsl/ProductQuerydslRepositoryImpl.java
+++ b/src/main/java/com/tunaforce/product/repository/querydsl/ProductQuerydslRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.tunaforce.product.repository.querydsl;
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -36,6 +37,13 @@ public class ProductQuerydslRepositoryImpl implements ProductQuerydslRepository 
             UUID companyId,
             String productName
     ) {
+        Predicate[] whereClause = {
+                eqHubId(hubId),
+                eqCompanyId(companyId),
+                eqProductName(productName),
+                product.deletedAt.isNull()
+        };
+
         // SELECT
         List<ProductDetailsQuerydslResponseDto> records = queryFactory
                 .select(new QProductDetailsQuerydslResponseDto(
@@ -49,12 +57,7 @@ public class ProductQuerydslRepositoryImpl implements ProductQuerydslRepository 
                         product.updatedAt
                 ))
                 .from(product)
-                .where(
-                        eqHubId(hubId),
-                        eqCompanyId(companyId),
-                        eqProductName(productName),
-                        product.deletedAt.isNull()
-                )
+                .where(whereClause)
                 .orderBy(getOrderSpecifiers(pageable.getSort()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -63,12 +66,7 @@ public class ProductQuerydslRepositoryImpl implements ProductQuerydslRepository 
         // COUNT
         JPAQuery<Long> count = queryFactory
                 .select(product.count())
-                .where(
-                        eqHubId(hubId),
-                        eqCompanyId(companyId),
-                        eqProductName(productName),
-                        product.deletedAt.isNull()
-                )
+                .where(whereClause)
                 .from(product);
 
         return PageableExecutionUtils.getPage(records, pageable, count::fetchOne);

--- a/src/main/java/com/tunaforce/product/repository/querydsl/dto/response/ProductDetailsQuerydslResponseDto.java
+++ b/src/main/java/com/tunaforce/product/repository/querydsl/dto/response/ProductDetailsQuerydslResponseDto.java
@@ -1,0 +1,29 @@
+package com.tunaforce.product.repository.querydsl.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ProductDetailsQuerydslResponseDto(
+        UUID productId,
+
+        UUID hubId,
+
+        UUID companyId,
+
+        String name,
+
+        Integer price,
+
+        Integer quantity,
+
+        LocalDateTime createdAt,
+
+        LocalDateTime updatedAt
+) {
+
+    @QueryProjection
+    public ProductDetailsQuerydslResponseDto {
+    }
+}

--- a/src/main/java/com/tunaforce/product/service/ProductService.java
+++ b/src/main/java/com/tunaforce/product/service/ProductService.java
@@ -114,6 +114,11 @@ public class ProductService {
             UUID userId,
             UserRole userRole
     ) {
+        // 배송 담당자는 상품 관리 목록은 조회 불가능
+        if (userRole.equals(UserRole.DELIVERY)) {
+            throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
+        }
+
         // 업체는 자신의 업체만 조회 가능
         if (userRole.equals(UserRole.COMPANY)) {
             throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
@@ -138,6 +143,11 @@ public class ProductService {
             UUID userId,
             UserRole userRole
     ) {
+        // 배송 담당자는 상품 관리 목록은 조회 불가능
+        if (userRole.equals(UserRole.DELIVERY)) {
+            throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
+        }
+
         // 로그인한 유저가 허브 담당자 일 때 요청한 업체가 소속 업체인지 확인
         if (userRole.equals(UserRole.HUB)) {
             HubFindInfoResponseDto hubInfo = hubFeignClient.findHubInfoByUserId(userId);

--- a/src/main/java/com/tunaforce/product/service/ProductService.java
+++ b/src/main/java/com/tunaforce/product/service/ProductService.java
@@ -114,16 +114,6 @@ public class ProductService {
             UUID userId,
             UserRole userRole
     ) {
-        // 배송 담당자는 상품 관리 목록은 조회 불가능
-        if (userRole.equals(UserRole.DELIVERY)) {
-            throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
-        }
-
-        // 업체는 자신의 업체만 조회 가능
-        if (userRole.equals(UserRole.COMPANY)) {
-            throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
-        }
-
         // 로그인한 유저가 허브 담당자 일 때 요청한 허브에 접근 가능한지 확인
         if (userRole.equals(UserRole.HUB)) {
             HubFindInfoResponseDto hubInfo = hubFeignClient.findHubInfoByUserId(userId);
@@ -143,11 +133,6 @@ public class ProductService {
             UUID userId,
             UserRole userRole
     ) {
-        // 배송 담당자는 상품 관리 목록은 조회 불가능
-        if (userRole.equals(UserRole.DELIVERY)) {
-            throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
-        }
-
         // 로그인한 유저가 허브 담당자 일 때 요청한 업체가 소속 업체인지 확인
         if (userRole.equals(UserRole.HUB)) {
             HubFindInfoResponseDto hubInfo = hubFeignClient.findHubInfoByUserId(userId);

--- a/src/main/java/com/tunaforce/product/service/ProductService.java
+++ b/src/main/java/com/tunaforce/product/service/ProductService.java
@@ -178,15 +178,21 @@ public class ProductService {
         return ProductFindPageResponseDto.from(page, hubs, companies);
     }
 
-    private static Set<UUID> getUniqueCompanyIds(Page<ProductDetailsQuerydslResponseDto> page) {
-        return page.getContent().stream()
-                .map(ProductDetailsQuerydslResponseDto::companyId)
-                .collect(Collectors.toSet());
-    }
-
+    /**
+     * 조회한 레코드 리스트에 포함된 Hub ID 값들을 중복 제거하여 Set으로 반환
+     */
     private static Set<UUID> getUniqueHubIds(Page<ProductDetailsQuerydslResponseDto> page) {
         return page.getContent().stream()
                 .map(ProductDetailsQuerydslResponseDto::hubId)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * 조회한 레코드 리스트에 포함된 Company ID 값들을 중복 제거하여 Set으로 반환
+     */
+    private static Set<UUID> getUniqueCompanyIds(Page<ProductDetailsQuerydslResponseDto> page) {
+        return page.getContent().stream()
+                .map(ProductDetailsQuerydslResponseDto::companyId)
                 .collect(Collectors.toSet());
     }
 

--- a/src/main/java/com/tunaforce/product/service/ProductService.java
+++ b/src/main/java/com/tunaforce/product/service/ProductService.java
@@ -114,6 +114,10 @@ public class ProductService {
             UUID userId,
             UserRole userRole
     ) {
+        if (userRole.equals(UserRole.COMPANY) || userRole.equals(UserRole.DELIVERY)) {
+            throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
+        }
+
         // 로그인한 유저가 허브 담당자 일 때 요청한 허브에 접근 가능한지 확인
         if (userRole.equals(UserRole.HUB)) {
             HubFindInfoResponseDto hubInfo = hubFeignClient.findHubInfoByUserId(userId);
@@ -133,6 +137,10 @@ public class ProductService {
             UUID userId,
             UserRole userRole
     ) {
+        if (userRole.equals(UserRole.DELIVERY)) {
+            throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
+        }
+
         // 로그인한 유저가 허브 담당자 일 때 요청한 업체가 소속 업체인지 확인
         if (userRole.equals(UserRole.HUB)) {
             HubFindInfoResponseDto hubInfo = hubFeignClient.findHubInfoByUserId(userId);
@@ -163,8 +171,8 @@ public class ProductService {
 
     private ProductFindPageResponseDto mapPageToResponse(Page<ProductDetailsQuerydslResponseDto> page) {
         // 조회한 레코드에서 허브와 업체 ID 중복 제거
-        Set<UUID> hubSet = getUniqueHubIds(page);
-        Set<UUID> companySet = getUniqueCompanyIds(page);
+        Set<UUID> hubSet = getUniqueHubIds(page.getContent());
+        Set<UUID> companySet = getUniqueCompanyIds(page.getContent());
 
         // 허브와 업체 정보(이름) 조회
         Map<UUID, String> hubs = getHubs(hubSet);

--- a/src/main/java/com/tunaforce/product/service/ProductService.java
+++ b/src/main/java/com/tunaforce/product/service/ProductService.java
@@ -30,6 +30,7 @@ public class ProductService {
 
         // persist a product
         Product product = Product.builder()
+                .hubId(request.hubId())
                 .companyId(request.companyId())
                 .name(request.name())
                 .price(request.price())

--- a/src/main/java/com/tunaforce/product/service/ProductService.java
+++ b/src/main/java/com/tunaforce/product/service/ProductService.java
@@ -19,14 +19,14 @@ public class ProductService {
 
     public void createProduct(ProductCreateRequestDto request, UUID userId) {
         // 유저 역할에 따라 상품 생성에 요청된 허브 또는 업체와 로그인한 유저의 허브 또는 업체와의 관계가 유효한지 검증
-        AuthCreateProductCheckUserAffiliationRequestDto authRequestDto =
-                new AuthCreateProductCheckUserAffiliationRequestDto(
-                        userId,
-                        request.hubId(),
-                        request.companyId()
-                );
-
-        authFeignClient.checkUserAffiliation(authRequestDto);
+//        AuthCreateProductCheckUserAffiliationRequestDto authRequestDto =
+//                new AuthCreateProductCheckUserAffiliationRequestDto(
+//                        userId,
+//                        request.hubId(),
+//                        request.companyId()
+//                );
+//
+//        authFeignClient.checkUserAffiliation(authRequestDto);
 
         // persist a product
         Product product = Product.builder()

--- a/src/main/java/com/tunaforce/product/service/ProductService.java
+++ b/src/main/java/com/tunaforce/product/service/ProductService.java
@@ -1,21 +1,40 @@
 package com.tunaforce.product.service;
 
-import com.tunaforce.product.dto.request.AuthCreateProductCheckUserAffiliationRequestDto;
+import com.tunaforce.product.common.exception.CustomRuntimeException;
+import com.tunaforce.product.common.exception.ProductException;
 import com.tunaforce.product.dto.request.ProductCreateRequestDto;
+import com.tunaforce.product.dto.response.ProductFindPageResponseDto;
 import com.tunaforce.product.entity.Product;
+import com.tunaforce.product.entity.UserRole;
 import com.tunaforce.product.repository.feign.auth.AuthFeignClient;
+import com.tunaforce.product.repository.feign.company.CompanyFeignClient;
+import com.tunaforce.product.repository.feign.company.dto.response.CompanyFindInfoListResponse;
+import com.tunaforce.product.repository.feign.company.dto.response.CompanyFindInfoResponseDto;
+import com.tunaforce.product.repository.feign.hub.HubFeignClient;
+import com.tunaforce.product.repository.feign.hub.dto.response.HubFindInfoListResponseDto;
+import com.tunaforce.product.repository.feign.hub.dto.response.HubFindInfoResponseDto;
 import com.tunaforce.product.repository.jpa.ProductJpaRepository;
+import com.tunaforce.product.repository.querydsl.ProductQuerydslRepository;
+import com.tunaforce.product.repository.querydsl.dto.response.ProductDetailsQuerydslResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ProductService {
 
+    private final HubFeignClient hubFeignClient;
     private final AuthFeignClient authFeignClient;
+    private final CompanyFeignClient companyFeignClient;
+
     private final ProductJpaRepository productJpaRepository;
+
+    private final ProductQuerydslRepository productQuerydslRepository;
 
     public void createProduct(ProductCreateRequestDto request, UUID userId) {
         // 유저 역할에 따라 상품 생성에 요청된 허브 또는 업체와 로그인한 유저의 허브 또는 업체와의 관계가 유효한지 검증
@@ -38,5 +57,83 @@ public class ProductService {
                 .build();
 
         productJpaRepository.save(product);
+    }
+
+    public ProductFindPageResponseDto findProductPage(
+            Pageable pageable,
+            String productName,
+            UUID userId,
+            UserRole userRole
+    ) {
+        Page<ProductDetailsQuerydslResponseDto> page
+                = findProductPageByAuthority(pageable, productName, userId, userRole);
+
+        // 조회한 레코드에서 허브와 업체 ID 중복 제거
+        Set<UUID> hubSet = page.getContent().stream()
+                .map(ProductDetailsQuerydslResponseDto::hubId)
+                .collect(Collectors.toSet());
+
+        Set<UUID> companySet = page.getContent().stream()
+                .map(ProductDetailsQuerydslResponseDto::companyId)
+                .collect(Collectors.toSet());
+
+        // 허브와 업체 정보(이름) 조회
+        Map<UUID, String> hubs = getHubs(hubSet);
+        Map<UUID, String> companies = getCompanies(companySet);
+
+        return ProductFindPageResponseDto.from(page, hubs, companies);
+    }
+
+    /**
+     * 권한 별 페이지네이션
+     */
+    private Page<ProductDetailsQuerydslResponseDto> findProductPageByAuthority(
+            Pageable pageable,
+            String productName,
+            UUID userId,
+            UserRole userRole
+    ) {
+        // MASTER - 전체 상품 조회
+        if (userRole.equals(UserRole.MASTER)) {
+            return productQuerydslRepository.findPage(pageable, null, null, productName);
+        }
+
+        // HUB - 특정 허브(로그인 유저) 소속 업체들이 등록한 상품 조회
+        if (userRole.equals(UserRole.HUB)) {
+            HubFindInfoResponseDto hubInfo = hubFeignClient.findHubInfoByUserId(userId);
+            return productQuerydslRepository.findPage(pageable, hubInfo.hubId(), null, productName);
+        }
+
+        // COMPANY - 특정 업체(로그인 유저)가 등록한 상품 조회
+        if (userRole.equals(UserRole.COMPANY)) {
+            CompanyFindInfoResponseDto companyInfo = companyFeignClient.findCompanyInfoByUserId(userId);
+            return productQuerydslRepository.findPage(pageable, null, companyInfo.companyId(), productName);
+        }
+
+        throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
+    }
+
+    /**
+     * 허브 이름 조회
+     */
+    private Map<UUID, String> getHubs(Set<UUID> hubSet) {
+        if (hubSet.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        HubFindInfoListResponseDto hubs = hubFeignClient.findHubInfoListByHubIds(new ArrayList<>(hubSet));
+        return hubs.toMap();
+    }
+
+    /**
+     * 업체 이름 조회
+     */
+    private Map<UUID, String> getCompanies(Set<UUID> companySet) {
+        if (companySet.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        CompanyFindInfoListResponse companies = companyFeignClient.findCompanyInfoListByCompanyIds(new ArrayList<>(companySet));
+        return companies.toMap();
     }
 }

--- a/src/main/java/com/tunaforce/product/service/ProductService.java
+++ b/src/main/java/com/tunaforce/product/service/ProductService.java
@@ -69,24 +69,26 @@ public class ProductService {
             UUID userId,
             UserRole userRole
     ) {
-
         Page<ProductDetailsQuerydslResponseDto> page
                 = findHubProductPageByAuthority(pageable, hubId, productName, userId, userRole);
 
-        // 조회한 레코드에서 허브와 업체 ID 중복 제거
-        Set<UUID> hubSet = page.getContent().stream()
-                .map(ProductDetailsQuerydslResponseDto::hubId)
-                .collect(Collectors.toSet());
+        return mapPageToResponse(page);
+    }
 
-        Set<UUID> companySet = page.getContent().stream()
-                .map(ProductDetailsQuerydslResponseDto::companyId)
-                .collect(Collectors.toSet());
+    /**
+     * 허브 소속 업체들이 등록한 상품 페이지네이션
+     */
+    public ProductFindPageResponseDto findProductPageByCompany(
+            Pageable pageable,
+            UUID companyId,
+            String productName,
+            UUID userId,
+            UserRole userRole
+    ) {
+        Page<ProductDetailsQuerydslResponseDto> page
+                = findCompanyProductPageByAuthority(pageable, companyId, productName, userId, userRole);
 
-        // 허브와 업체 정보(이름) 조회
-        Map<UUID, String> hubs = getHubs(hubSet);
-        Map<UUID, String> companies = getCompanies(companySet);
-
-        return ProductFindPageResponseDto.from(page, hubs, companies);
+        return mapPageToResponse(page);
     }
 
     private Page<ProductDetailsQuerydslResponseDto> findHubProductPageByAuthority(
@@ -96,10 +98,12 @@ public class ProductService {
             UUID userId,
             UserRole userRole
     ) {
+        // 업체는 자신의 업체만 조회 가능
         if (userRole.equals(UserRole.COMPANY)) {
             throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
         }
 
+        // 로그인한 유저가 허브 담당자 일 때 요청한 허브에 접근 가능한지 확인
         if (userRole.equals(UserRole.HUB)) {
             HubFindInfoResponseDto hubInfo = hubFeignClient.findHubInfoByUserId(userId);
             validateUuidMatch(hubId, hubInfo.hubId());
@@ -108,10 +112,63 @@ public class ProductService {
         return productQuerydslRepository.findPage(pageable, hubId, null, productName);
     }
 
+    private Page<ProductDetailsQuerydslResponseDto> findCompanyProductPageByAuthority(
+            Pageable pageable,
+            UUID companyId,
+            String productName,
+            UUID userId,
+            UserRole userRole
+    ) {
+        // 로그인한 유저가 허브 담당자 일 때 요청한 업체가 소속 업체인지 확인
+        if (userRole.equals(UserRole.HUB)) {
+            HubFindInfoResponseDto hubInfo = hubFeignClient.findHubInfoByUserId(userId);
+            CompanyFindInfoListResponse companyInfos
+                    = companyFeignClient.findCompanyInfoListByCompanyIds(List.of(companyId));
+
+            CompanyFindInfoResponseDto companyInfo = companyInfos.data().stream().findFirst()
+                    .orElseThrow(() -> new CustomRuntimeException(ProductException.COMPANY_NOT_FOUND));
+
+            // 로그인한 유저의 허브가 요청한 업체의 담당 허브인지 확인
+            validateUuidMatch(hubInfo.hubId(), companyInfo.hubId());
+        }
+
+        // 로그인한 유저가 업체 담당자 일 때 자신의 업체인지 확인
+        if (userRole.equals(UserRole.COMPANY)) {
+            CompanyFindInfoResponseDto companyInfo = companyFeignClient.findCompanyInfoByUserId(userId);
+            validateUuidMatch(companyId, companyInfo.companyId());
+        }
+
+        return productQuerydslRepository.findPage(pageable, null, companyId, productName);
+    }
+
     public void validateUuidMatch(UUID expectedId, UUID actualId) {
         if (!expectedId.equals(actualId)) {
             throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
         }
+    }
+
+    public ProductFindPageResponseDto mapPageToResponse(Page<ProductDetailsQuerydslResponseDto> page) {
+        // 조회한 레코드에서 허브와 업체 ID 중복 제거
+        Set<UUID> hubSet = getUniqueHubIdSet(page);
+        Set<UUID> companySet = getUniqueCompanyIdSet(page);
+
+        // 허브와 업체 정보(이름) 조회
+        Map<UUID, String> hubs = getHubs(hubSet);
+        Map<UUID, String> companies = getCompanies(companySet);
+
+        return ProductFindPageResponseDto.from(page, hubs, companies);
+    }
+
+    private static Set<UUID> getUniqueCompanyIdSet(Page<ProductDetailsQuerydslResponseDto> page) {
+        return page.getContent().stream()
+                .map(ProductDetailsQuerydslResponseDto::companyId)
+                .collect(Collectors.toSet());
+    }
+
+    private static Set<UUID> getUniqueHubIdSet(Page<ProductDetailsQuerydslResponseDto> page) {
+        return page.getContent().stream()
+                .map(ProductDetailsQuerydslResponseDto::hubId)
+                .collect(Collectors.toSet());
     }
 
     public ProductFindPageResponseDto findProductPage(

--- a/src/main/java/com/tunaforce/product/service/ProductService.java
+++ b/src/main/java/com/tunaforce/product/service/ProductService.java
@@ -62,7 +62,7 @@ public class ProductService {
     /**
      * 주문 용 전체 상품 페이지네이션
      */
-    public ProductFindPageResponseDto findProductPage(
+    public ProductFindPageResponseDto findProductPageForOrder(
             Pageable pageable,
             String productName
     ) {

--- a/src/main/java/com/tunaforce/product/service/ProductService.java
+++ b/src/main/java/com/tunaforce/product/service/ProductService.java
@@ -59,6 +59,61 @@ public class ProductService {
         productJpaRepository.save(product);
     }
 
+    /**
+     * 허브 소속 업체들이 등록한 상품 페이지네이션
+     */
+    public ProductFindPageResponseDto findProductPageByHub(
+            Pageable pageable,
+            UUID hubId,
+            String productName,
+            UUID userId,
+            UserRole userRole
+    ) {
+
+        Page<ProductDetailsQuerydslResponseDto> page
+                = findHubProductPageByAuthority(pageable, hubId, productName, userId, userRole);
+
+        // 조회한 레코드에서 허브와 업체 ID 중복 제거
+        Set<UUID> hubSet = page.getContent().stream()
+                .map(ProductDetailsQuerydslResponseDto::hubId)
+                .collect(Collectors.toSet());
+
+        Set<UUID> companySet = page.getContent().stream()
+                .map(ProductDetailsQuerydslResponseDto::companyId)
+                .collect(Collectors.toSet());
+
+        // 허브와 업체 정보(이름) 조회
+        Map<UUID, String> hubs = getHubs(hubSet);
+        Map<UUID, String> companies = getCompanies(companySet);
+
+        return ProductFindPageResponseDto.from(page, hubs, companies);
+    }
+
+    private Page<ProductDetailsQuerydslResponseDto> findHubProductPageByAuthority(
+            Pageable pageable,
+            UUID hubId,
+            String productName,
+            UUID userId,
+            UserRole userRole
+    ) {
+        if (userRole.equals(UserRole.COMPANY)) {
+            throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
+        }
+
+        if (userRole.equals(UserRole.HUB)) {
+            HubFindInfoResponseDto hubInfo = hubFeignClient.findHubInfoByUserId(userId);
+            validateUuidMatch(hubId, hubInfo.hubId());
+        }
+
+        return productQuerydslRepository.findPage(pageable, hubId, null, productName);
+    }
+
+    public void validateUuidMatch(UUID expectedId, UUID actualId) {
+        if (!expectedId.equals(actualId)) {
+            throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
+        }
+    }
+
     public ProductFindPageResponseDto findProductPage(
             Pageable pageable,
             String productName,

--- a/src/main/java/com/tunaforce/product/service/ProductService.java
+++ b/src/main/java/com/tunaforce/product/service/ProductService.java
@@ -155,13 +155,13 @@ public class ProductService {
         return productQuerydslRepository.findPage(pageable, null, companyId, productName);
     }
 
-    public void validateUuidMatch(UUID expectedId, UUID actualId) {
+    private void validateUuidMatch(UUID expectedId, UUID actualId) {
         if (!expectedId.equals(actualId)) {
             throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
         }
     }
 
-    public ProductFindPageResponseDto mapPageToResponse(Page<ProductDetailsQuerydslResponseDto> page) {
+    private ProductFindPageResponseDto mapPageToResponse(Page<ProductDetailsQuerydslResponseDto> page) {
         // 조회한 레코드에서 허브와 업체 ID 중복 제거
         Set<UUID> hubSet = getUniqueHubIds(page);
         Set<UUID> companySet = getUniqueCompanyIds(page);
@@ -176,8 +176,8 @@ public class ProductService {
     /**
      * 조회한 레코드 리스트에 포함된 Hub ID 값들을 중복 제거하여 Set으로 반환
      */
-    private static Set<UUID> getUniqueHubIds(Page<ProductDetailsQuerydslResponseDto> page) {
-        return page.getContent().stream()
+    private static Set<UUID> getUniqueHubIds(List<ProductDetailsQuerydslResponseDto> data) {
+        return data.stream()
                 .map(ProductDetailsQuerydslResponseDto::hubId)
                 .collect(Collectors.toSet());
     }
@@ -185,8 +185,8 @@ public class ProductService {
     /**
      * 조회한 레코드 리스트에 포함된 Company ID 값들을 중복 제거하여 Set으로 반환
      */
-    private static Set<UUID> getUniqueCompanyIds(Page<ProductDetailsQuerydslResponseDto> page) {
-        return page.getContent().stream()
+    private static Set<UUID> getUniqueCompanyIds(List<ProductDetailsQuerydslResponseDto> data) {
+        return data.stream()
                 .map(ProductDetailsQuerydslResponseDto::companyId)
                 .collect(Collectors.toSet());
     }

--- a/src/main/java/com/tunaforce/product/service/ProductService.java
+++ b/src/main/java/com/tunaforce/product/service/ProductService.java
@@ -60,6 +60,19 @@ public class ProductService {
     }
 
     /**
+     * 주문 용 전체 상품 페이지네이션
+     */
+    public ProductFindPageResponseDto findProductPage(
+            Pageable pageable,
+            String productName
+    ) {
+        Page<ProductDetailsQuerydslResponseDto> page
+                = productQuerydslRepository.findPage(pageable, null, null, productName);
+
+        return mapPageToResponse(page);
+    }
+
+    /**
      * 허브 소속 업체들이 등록한 상품 페이지네이션
      */
     public ProductFindPageResponseDto findProductPageByHub(
@@ -91,6 +104,9 @@ public class ProductService {
         return mapPageToResponse(page);
     }
 
+    /**
+     * 특정 허브 소속 업체들의 등록 상품에 대한 권한별 조회
+     */
     private Page<ProductDetailsQuerydslResponseDto> findHubProductPageByAuthority(
             Pageable pageable,
             UUID hubId,
@@ -112,6 +128,9 @@ public class ProductService {
         return productQuerydslRepository.findPage(pageable, hubId, null, productName);
     }
 
+    /**
+     * 특정 업체의 등록 상품에 대한 권한별 조회
+     */
     private Page<ProductDetailsQuerydslResponseDto> findCompanyProductPageByAuthority(
             Pageable pageable,
             UUID companyId,
@@ -149,8 +168,8 @@ public class ProductService {
 
     public ProductFindPageResponseDto mapPageToResponse(Page<ProductDetailsQuerydslResponseDto> page) {
         // 조회한 레코드에서 허브와 업체 ID 중복 제거
-        Set<UUID> hubSet = getUniqueHubIdSet(page);
-        Set<UUID> companySet = getUniqueCompanyIdSet(page);
+        Set<UUID> hubSet = getUniqueHubIds(page);
+        Set<UUID> companySet = getUniqueCompanyIds(page);
 
         // 허브와 업체 정보(이름) 조회
         Map<UUID, String> hubs = getHubs(hubSet);
@@ -159,70 +178,16 @@ public class ProductService {
         return ProductFindPageResponseDto.from(page, hubs, companies);
     }
 
-    private static Set<UUID> getUniqueCompanyIdSet(Page<ProductDetailsQuerydslResponseDto> page) {
+    private static Set<UUID> getUniqueCompanyIds(Page<ProductDetailsQuerydslResponseDto> page) {
         return page.getContent().stream()
                 .map(ProductDetailsQuerydslResponseDto::companyId)
                 .collect(Collectors.toSet());
     }
 
-    private static Set<UUID> getUniqueHubIdSet(Page<ProductDetailsQuerydslResponseDto> page) {
+    private static Set<UUID> getUniqueHubIds(Page<ProductDetailsQuerydslResponseDto> page) {
         return page.getContent().stream()
                 .map(ProductDetailsQuerydslResponseDto::hubId)
                 .collect(Collectors.toSet());
-    }
-
-    public ProductFindPageResponseDto findProductPage(
-            Pageable pageable,
-            String productName,
-            UUID userId,
-            UserRole userRole
-    ) {
-        Page<ProductDetailsQuerydslResponseDto> page
-                = findProductPageByAuthority(pageable, productName, userId, userRole);
-
-        // 조회한 레코드에서 허브와 업체 ID 중복 제거
-        Set<UUID> hubSet = page.getContent().stream()
-                .map(ProductDetailsQuerydslResponseDto::hubId)
-                .collect(Collectors.toSet());
-
-        Set<UUID> companySet = page.getContent().stream()
-                .map(ProductDetailsQuerydslResponseDto::companyId)
-                .collect(Collectors.toSet());
-
-        // 허브와 업체 정보(이름) 조회
-        Map<UUID, String> hubs = getHubs(hubSet);
-        Map<UUID, String> companies = getCompanies(companySet);
-
-        return ProductFindPageResponseDto.from(page, hubs, companies);
-    }
-
-    /**
-     * 권한 별 페이지네이션
-     */
-    private Page<ProductDetailsQuerydslResponseDto> findProductPageByAuthority(
-            Pageable pageable,
-            String productName,
-            UUID userId,
-            UserRole userRole
-    ) {
-        // MASTER - 전체 상품 조회
-        if (userRole.equals(UserRole.MASTER)) {
-            return productQuerydslRepository.findPage(pageable, null, null, productName);
-        }
-
-        // HUB - 특정 허브(로그인 유저) 소속 업체들이 등록한 상품 조회
-        if (userRole.equals(UserRole.HUB)) {
-            HubFindInfoResponseDto hubInfo = hubFeignClient.findHubInfoByUserId(userId);
-            return productQuerydslRepository.findPage(pageable, hubInfo.hubId(), null, productName);
-        }
-
-        // COMPANY - 특정 업체(로그인 유저)가 등록한 상품 조회
-        if (userRole.equals(UserRole.COMPANY)) {
-            CompanyFindInfoResponseDto companyInfo = companyFeignClient.findCompanyInfoByUserId(userId);
-            return productQuerydslRepository.findPage(pageable, null, companyInfo.companyId(), productName);
-        }
-
-        throw new CustomRuntimeException(ProductException.ACCESS_DENIED);
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: product-service
+    name: products
 
   profiles:
     active: dev

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,8 +9,3 @@ spring:
     openfeign:
       circuitbreaker:
         enabled: true
-
-eureka:
-  client:
-    service-url:
-      defaultZone: http://0.0.0.0:3310/eureka


### PR DESCRIPTION
## 작업 내용
- 전체 상품 조회: 주문하기전 상품 목록 페이지네이션
- 등록 상품 조회: 로그인 유저 권한 별 상품 목록 페이지네이션

## 관련 이슈
#10 

## 작업 상세 내용
- 상품 테이블 내 `hub_id` 컬럼 추가
- 정렬
  - `createdAt` `updatedAt` `price` 값들에 대해 ASC, DESC 가능하도록 했습니다.
- 권한 별 페이지네이션
  - 마스터: 모든 허브 및 업체 등록 상품 조회
  - 허브: 특정 허브 내 업체들이 등록한 상품만 조회 가능
  - 업체: 특정 업체가 등록한 상품만 조회 가능
- Dependency 추가
  - Querydsl 5.1.0
  
- 너무 길어졌네요 죄송해요 ㅠ